### PR TITLE
ZIMBRA-95: Related Contacts

### DIFF
--- a/conf/configsets/events/conf/schema.xml
+++ b/conf/configsets/events/conf/schema.xml
@@ -22,10 +22,13 @@
     <field name="id" type="string" indexed="true" stored="true" />
     <field name="_root_" type="string" indexed="true" stored="false"/>
     <field name="ev_type" type="string" indexed="true" stored="false" required="false"/>
-    <field name="ev_timestamp" type="pdate" indexed="true" stored="true" required="false"/>
-    <field name="msg_id" type="pint" indexed="true" stored="false" required="false"/>
+    <field name="ev_timestamp" type="date" indexed="true" stored="true" required="false"/>
+    <field name="msg_id" type="int" indexed="true" stored="false" required="false"/>
     <field name="acct_id" type="string" indexed="true" stored="false" required="false" />
     <field name="datasource_id" type="string" indexed="true" stored="false" required="false" />
+
+    <!--copy indexed address fields into a stored field for retrieval-->
+    <copyField source="*_zaddr" dest="*_s"/>
 
     <uniqueKey>id</uniqueKey>
 
@@ -68,6 +71,9 @@
     <dynamicField name="*_tds" type="tdoubles" indexed="true"  stored="true"/>
     <dynamicField name="*_tdt" type="tdate"  indexed="true"  stored="true"/>
     <dynamicField name="*_tdts" type="tdates"  indexed="true"  stored="true"/>
+
+    <!-- dynamic field used for event address fields -->
+    <dynamicField name="*_zaddr" type="zmaddress" indexed="true" stored="false"/>
 
     <!-- field type definitions -->
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
@@ -139,5 +145,14 @@
     <fieldType name="tdates" class="solr.TrieDateField" docValues="true" precisionStep="6" positionIncrementGap="0" multiValued="true"/>
 
     <fieldType name="binary" class="solr.BinaryField"/>
+
+    <fieldType name="zmaddress" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
+      </analyzer>
+    </fieldType>
 
 </schema>


### PR DESCRIPTION
Several Solr schema changes are needed for event-driven related contacts functionality.

#### Removal of point numeric fields
The `events` configset used point numeric field types `pdate` and `pint` for the two non-string event fields `ev_timestamp` and `msg_id`. Point numerics are meant to provide query performance improvements and index size reductions . However, point numerics are incompatible with one of the stream operations used to calculate contact affinity. To this end, the `ev_timestamp` and `msg_id` fields have been changes to standard types `date` and `int`. Given the way that these fields are queried, I do not think that removing the point field types will cause any problems.

#### Address field tokenization
In order to be able to return the contact name as well as email address, sender and recipient fields now store the entire RFC-822-formatted address (when available). In order to search these fields by email address, these fields now need to be tokenized. The `ZimbraAddressTokenizerFactory` that is used by the `zimbra` configset to parse email addresses works for this, since it tokenizes loosely based on the RFC-822 format. (This is actually a broader tokenizer than is needed, since it generates tokens for domains and individual parts of names, but it works well for this use case). The `zmaddress` field type has been added to the schema that uses `ZimbraAddressTokenizerFactory` for analysis.
Since sender and recipient fields are dynamic, a new dynamic field type `*_zaddr` has been added; dynamic fields with this pattern are created with type `zmaddress`. A `copyField` directive copies `*_zaddr` fields into stored `*_s` fields, which are used to retrieve the addresses.

Note: ideally, the `*_zaddr` fields themselves would be stored to avoid having to use `copyField`. However, the `gatherNodes` stream operation uses the `export` handler internally, which requires DocValues to be enabled on all exported fields. Since DocValues can't be enabled on analyzed fields, we need to copy the value into a different field that _can_ be exported.


