### PR TITLE
ZCS-4213: Shared Solr Index Architecture

### DIFF
--- a/conf/configsets/zimbra/conf/schema.xml
+++ b/conf/configsets/zimbra/conf/schema.xml
@@ -159,6 +159,7 @@
     <field name="sh_exact" type="zmid" indexed="true" stored="true"  multiValued="false" />
     <field name="sh_terms" type="zmsearchhistory" indexed="true" stored="false" multiValued="false" />
     <field name="doctype" type="string" indexed="true" stored="false" multiValued="false" />
+    <field name="acct_id" type="string" indexed="true" stored="false" required="true" />
 
     <!-- Only enabled in the "schemaless" data-driven example (assuming the client
          does not know what fields may be searched) because it's very expensive to index everything twice. -->

--- a/conf/configsets/zimbra/conf/schema.xml
+++ b/conf/configsets/zimbra/conf/schema.xml
@@ -125,7 +125,7 @@
     <field name="solrId" type="string" indexed="true" stored="true" required="true" />
     <field name="l.mbox_blob_id" type="int" indexed="true" stored="true"  multiValued="false" />
     <field name="l.version" type="string" indexed="true" stored="true" />
-    <field name="has" type="zmtext_nr" indexed="true" stored="false"/>
+    <field name="has" type="zmtext_noreverse" indexed="true" stored="false"/>
     <field name="l.contactData" type="zmcontact" indexed="true" stored="false"/>
     <field name="l.date" type="zmdate" indexed="true" stored="true"/>
     <field name="attachment" type="zmmimetype" indexed="true" stored="true" multiValued="true" />
@@ -140,15 +140,14 @@
     <field name="cc" type="zmaddress" indexed="true" stored="true" />
     <field name="to" type="zmaddress" indexed="true" stored="true" />
     <field name="from" type="zmaddress" indexed="true" stored="true" />
-    <field name="cc_sw" type="zmaddress_sw" indexed="true" stored="true" />
-    <field name="to_sw" type="zmaddress_sw" indexed="true" stored="true" />
-    <field name="from_sw" type="zmaddress_sw" indexed="true" stored="true" />
+    <field name="cc_search" type="zmaddress_search" indexed="true" stored="true" />
+    <field name="to_search" type="zmaddress_search" indexed="true" stored="true" />
+    <field name="from_search" type="zmaddress_search" indexed="true" stored="true" />
     <field name="priority" type="string" indexed="true" stored="true" omitNorms="true"/>
     <field name="hasFlag" type="int" indexed="true" stored="true" omitNorms="true"/>
     <field name="hasAttach" type="int" indexed="true" stored="true" omitNorms="true"/>
     <field name="l.size" type="zmnumber" indexed="true" stored="true" />
     <field name="filename" type="zmfilename" indexed="true" stored="true" />
-    <field name="filename_sw" type="zmfilename_sw" indexed="true" stored="true" />
     <field name="l.partname" type="string" indexed="true" stored="true" />
     <field name="type" type="zmmimetype" indexed="true" stored="true" />
     <field name="author" type="zmtext" indexed="true" stored="false"/>
@@ -190,10 +189,9 @@
 
     <copyField source="sourceFieldName" dest="destinationFieldName"/>
     -->
-    <copyField source="from" dest="from_sw"/>
-    <copyField source="to" dest="to_sw"/>
-    <copyField source="cc" dest="cc_sw"/>
-    <copyField source="filename" dest="filename_sw"/>
+    <copyField source="from" dest="from_search"/>
+    <copyField source="to" dest="to_search"/>
+    <copyField source="cc" dest="cc_search"/>
     <copyField source="sh_exact" dest="sh_terms"/>
 
     <!-- field type definitions. The "name" attribute is
@@ -346,25 +344,21 @@
     <fieldType name="zmaddress" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
             <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
-            <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
-           maxPosAsterisk="3" maxPosQuestion="2" />
       </analyzer>
       <analyzer type="query">
             <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
       </analyzer>
     </fieldType>
-    <fieldType name="zmaddress_sw" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+    <fieldType name="zmaddress_search" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-halfwidth-kana-voiced.txt"/>
             <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
-            <filter class="solr.StopFilterFactory"/>
             <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
            maxPosAsterisk="3" maxPosQuestion="2" />
       </analyzer>
       <analyzer type="query">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-halfwidth-kana-voiced.txt"/>
             <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
-            <filter class="solr.StopFilterFactory"/>
       </analyzer>
     </fieldType>
     <fieldType name="zmtext" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
@@ -385,7 +379,7 @@
         <filter class="com.zimbra.solr.ZimbraClassicTokenFilterFactory"/>
       </analyzer>
     </fieldType>
-    <fieldType name="zmtext_nr" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
+    <fieldType name="zmtext_noreverse" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-halfwidth-kana-voiced.txt"/>
         <charFilter class="com.zimbra.solr.ZimbraCharFilterFactory"/>
@@ -417,13 +411,6 @@
       <analyzer>
             <tokenizer class="solr.PatternTokenizerFactory" pattern="[,\s\r\n\.]"/>
             <filter class="solr.LowerCaseFilterFactory"/>
-      </analyzer>
-    </fieldType>
-    <fieldType name="zmfilename_sw" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-            <tokenizer class="solr.PatternTokenizerFactory" pattern="[,\s\r\n\.]"/>
-            <filter class="solr.LowerCaseFilterFactory"/>
-            <filter class="solr.StopFilterFactory"/>
       </analyzer>
     </fieldType>
     <fieldType name="zmmimetype" class="solr.TextField" positionIncrementGap="100">

--- a/conf/configsets/zimbra/conf/schema.xml
+++ b/conf/configsets/zimbra/conf/schema.xml
@@ -133,7 +133,7 @@
     <field name="subjSort" type="string" indexed="true" stored="false"/>
     <field name="subject" type="zmtext" indexed="true" stored="false" omitNorms="true" termVectors="true"/>
     <field name="nameSort" type="string" indexed="true" stored="false"/>
-    <field name="l.field" type="zmheaders" indexed="true" stored="true" multiValued="true"/>
+    <field name="l.field" type="zmheaders" indexed="true" stored="false" multiValued="true"/>
     <field name="msg_id" type="zmid" indexed="true" stored="false"/>
     <field name="env_to" type="zmaddress" indexed="true" stored="true" />
     <field name="env_from" type="zmaddress" indexed="true" stored="true"/>


### PR DESCRIPTION
This PR adds support for the shared-index architecture described in https://github.com/Zimbra/zm-mailbox/pull/531.

#### Account ID Field
A new schema field `acct_id` has been added. This is used by the server to restrict search results to the given account.

#### StopWord / ReversedWildcard changes
Changes have also been made to how address and filename fields are handled. The reason for this is twofold:
1. As part of the move to a shared index architecture, domain enumeration is now performed using facets, which is liable to return reversed tokens introduced by `ReversedWildcardFilterFactory`.
2. The old Lucene backend indexed addresses and filenames separately _without_ dropping stop words, but also appended them to the `l.content` field that _did_ drop them. The intent was to allow for text searches to include fields other than the message content, but for some reason did not do this by simply querying multiple fields. The `*_sw` fields in Solr were an initial attempt to replicate this search behavior _exactly_, but in retrospect, we were replicating a limitation of the old system.

To this end:
- The `zmaddress` field type no longer includes `ReversedWildcardFilterFactory`
- `zmaddress_sw` has been renamed to `zmaddress_search`, and no longer includes `StopFilterFactory`.
 - The `to`, `from`, and `cc` fields are copied to `to_search`, `from_search`, and `cc_search`, respectively. Search queries are routed to the appropriate `*_search` field for leading wildcard support, while facet queries are run against the original fields that do not contain reversed tokens.

Other small changes:
- `zmtext_nr` has been renamed to `zmtext_noreverse` for clarity
- The `l.field` is no longer stored. This field is only used for searching, so storing it is wasteful.
- The `filename_sw` field and corresponding `zmfilename_sw`field type have been removed; filenames are now indexed with stop words for the same reason as described above
