### PR TITLE
ZCS-4384: Unescape search string in WildcardQueryParser

### DIFF
--- a/src/java/com/zimbra/solr/WildcardQueryParser.java
+++ b/src/java/com/zimbra/solr/WildcardQueryParser.java
@@ -51,6 +51,7 @@ public class WildcardQueryParser extends QueryParser {
 
 	@Override
 	public Query parse(String queryText) throws ParseException {
+	    queryText = queryText.replace("\\", "");
 		boolean hasWildcard = queryText.contains("*");
 		if (queryText.startsWith("+") || queryText.startsWith("-")) {
 			queryText = queryText.substring(1, queryText.length());


### PR DESCRIPTION
The bug was being caused by our custom `WildcardQueryParser` not unescaping the passed-in search string. 
If a client issues a search `#foo:bar*`, it is compiled to a Solr query `l.field:foo\:bar*`. The query parser receives the string `foo\:bar*`, which, if unescaped, does not match any terms.
The fix is simply to remove the escape character `\\` from the query.