### PR TITLE
ZCS-4385: Updated Numeric Header Indexing

### DIFF
--- a/conf/configsets/zimbra/conf/schema.xml
+++ b/conf/configsets/zimbra/conf/schema.xml
@@ -160,6 +160,8 @@
     <field name="doctype" type="string" indexed="true" stored="false" multiValued="false" />
     <field name="acct_id" type="string" indexed="true" stored="false" required="true" />
 
+    <dynamicField name="header_*" type="pints" indexed="true" stored="false"/>
+
     <!-- Only enabled in the "schemaless" data-driven example (assuming the client
          does not know what fields may be searched) because it's very expensive to index everything twice. -->
     <!-- <copyField source="*" dest="_text_"/> -->


### PR DESCRIPTION
This is the companion PR to https://github.com/Zimbra/zm-mailbox/pull/551.

There are two main changes here:
1. The  Solr schema for the `zimbra` configset has been updated with a new dynamic field definition `header_*`, which creates fields of the `pints` type. This allows us to index arbitrary numeric email headers using the `IntPointField` field type.
2. The `FieldTokenizer` class used to tokenizer email headers no longer generates special prefix-coded tokens for numeric values. As explained in the other PR, range queries on headers are now routed to the specific field of the form `header_[name]`.