### PR TITLE
ZCS-4242: Upgrade to Solr 7

### DIFF
--- a/conf/configsets/events/conf/solrconfig.xml
+++ b/conf/configsets/events/conf/solrconfig.xml
@@ -21,7 +21,7 @@
      this file, see http://wiki.apache.org/solr/SolrConfigXml. 
 -->
 <config>
-  <luceneMatchVersion>6.6.0</luceneMatchVersion>
+  <luceneMatchVersion>7.2.1</luceneMatchVersion>
 
   <lib dir="${solr.install.dir:../../../..}/contrib/extraction/lib" regex=".*\.jar" />
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-cell-\d.*\.jar" />

--- a/conf/configsets/zimbra/conf/solrconfig.xml
+++ b/conf/configsets/zimbra/conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>6.6.0</luceneMatchVersion>
+  <luceneMatchVersion>7.2.1</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in

--- a/ivy.xml
+++ b/ivy.xml
@@ -14,11 +14,11 @@
   <dependency org="org.apache.httpcomponents" name="httpmime" rev="4.3.5"/>
   <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5"/>
   <dependency org="commons-io" name="commons-io" rev="2.5"/>
-  <dependency org="org.apache.lucene" name="lucene-core" rev="6.6.0"/>
-  <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="6.6.0" />
-  <dependency org="org.apache.lucene" name="lucene-queryparser" rev="6.6.0" />
-  <dependency org="org.apache.solr" name="solr-solrj" rev="6.6.0" />
-  <dependency org="org.apache.solr" name="solr-core" rev="6.6.0" />
+  <dependency org="org.apache.lucene" name="lucene-core" rev="7.2.1"/>
+  <dependency org="org.apache.lucene" name="lucene-analyzers-common" rev="7.2.1" />
+  <dependency org="org.apache.lucene" name="lucene-queryparser" rev="7.2.1" />
+  <dependency org="org.apache.solr" name="solr-solrj" rev="7.2.1" />
+  <dependency org="org.apache.solr" name="solr-core" rev="7.2.1" />
   <dependency org="org.noggit" name="noggit" rev="0.7"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />
  </dependencies>

--- a/src/java/com/zimbra/solr/WildcardQueryParser.java
+++ b/src/java/com/zimbra/solr/WildcardQueryParser.java
@@ -13,8 +13,6 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
-import org.apache.lucene.index.Fields;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.Terms;
@@ -23,7 +21,6 @@ import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
-import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.Query;
@@ -299,11 +296,10 @@ public class WildcardQueryParser extends QueryParser {
 	/* modeled on TermsComponent.process() */
 	private List<Term> expandPrefix(String prefix, String field) throws IOException {
 		List<Term> expanded = new LinkedList<Term>();
-		Fields lfields = reader.fields();
-		if (lfields == null) {
+		Terms terms = reader.terms(field);
+		if (terms == null) {
 		    return expanded;
 		}
-		Terms terms = lfields.terms(field);
 		BytesRef prefixBytes = new BytesRef(prefix);
 		try {
 			TermsEnum termsEnum = terms.iterator();


### PR DESCRIPTION
This PR updates the `Solr/Lucene` versions to `7.2.1`. 

There is also one API-related change to `WildcardQueryParser`: the `LeafReader.fields()` method has been removed, instead replaced by `LeafReader::terms`.