### PR TITLE
ZCS-4597: consistent stopword handling for edismax fields

### DIFF
--- a/conf/configsets/zimbra/conf/schema.xml
+++ b/conf/configsets/zimbra/conf/schema.xml
@@ -140,14 +140,15 @@
     <field name="cc" type="zmaddress" indexed="true" stored="true" />
     <field name="to" type="zmaddress" indexed="true" stored="true" />
     <field name="from" type="zmaddress" indexed="true" stored="true" />
-    <field name="cc_search" type="zmaddress_search" indexed="true" stored="true" />
-    <field name="to_search" type="zmaddress_search" indexed="true" stored="true" />
-    <field name="from_search" type="zmaddress_search" indexed="true" stored="true" />
+    <field name="cc_search" type="zmaddress_search" indexed="true" stored="false" />
+    <field name="to_search" type="zmaddress_search" indexed="true" stored="false" />
+    <field name="from_search" type="zmaddress_search" indexed="true" stored="false" />
     <field name="priority" type="string" indexed="true" stored="true" omitNorms="true"/>
     <field name="hasFlag" type="int" indexed="true" stored="true" omitNorms="true"/>
     <field name="hasAttach" type="int" indexed="true" stored="true" omitNorms="true"/>
     <field name="l.size" type="zmnumber" indexed="true" stored="true" />
     <field name="filename" type="zmfilename" indexed="true" stored="true" />
+    <field name="filename_search" type="zmfilename_search" indexed="true" stored="false" />
     <field name="l.partname" type="string" indexed="true" stored="true" />
     <field name="type" type="zmmimetype" indexed="true" stored="true" />
     <field name="author" type="zmtext" indexed="true" stored="false"/>
@@ -194,6 +195,7 @@
     <copyField source="from" dest="from_search"/>
     <copyField source="to" dest="to_search"/>
     <copyField source="cc" dest="cc_search"/>
+    <copyField source="filename" dest="filename_search"/>
     <copyField source="sh_exact" dest="sh_terms"/>
 
     <!-- field type definitions. The "name" attribute is
@@ -355,12 +357,14 @@
       <analyzer type="index">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-halfwidth-kana-voiced.txt"/>
             <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory"/>
             <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
            maxPosAsterisk="3" maxPosQuestion="2" />
       </analyzer>
       <analyzer type="query">
             <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-halfwidth-kana-voiced.txt"/>
             <tokenizer class="com.zimbra.solr.ZimbraAddressTokenizerFactory"/>
+            <filter class="solr.StopFilterFactory"/>
       </analyzer>
     </fieldType>
     <fieldType name="zmtext" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
@@ -413,6 +417,13 @@
       <analyzer>
             <tokenizer class="solr.PatternTokenizerFactory" pattern="[,\s\r\n\.]"/>
             <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+    <fieldType name="zmfilename_search" class="solr.TextField" positionIncrementGap="100">
+      <analyzer>
+            <tokenizer class="solr.PatternTokenizerFactory" pattern="[,\s\r\n\.]"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.StopFilterFactory"/>
       </analyzer>
     </fieldType>
     <fieldType name="zmmimetype" class="solr.TextField" positionIncrementGap="100">


### PR DESCRIPTION
When a search query compiles to an index search on the `l.content` field (such as one or more text clauses), it is actually rewritten by the `SolrIndex` class as an `edismax` query targeting the fields `l.content`, `subject`, `to_search`, `from_search`, `cc_search`, and `filename`. (Pre-Solr, these fields were originally indexed directly in the `l.content` field, hence the rewrite). However, edismax as a known issue wherein it returns no results if the queried fields have inconsistent stopword handling. In our case, the `l.content` and `subject` fields include a stopword filter, while the others don't. 
The solution is twofold:
-  add `StopFilterFactory` to the `zmaddress_search` field type
- add a `zmfilename_search` field type and corresponding `filename_search` field that includes `StopFilterFactory`.

Additionally, I made all `*_search` fields non-stored, since we are never returning them in the response.