### PR TITLE
ZCS-4147: Attachment type indexing

### DIFF
--- a/src/java/com/zimbra/solr/MimeTypeTokenizer.java
+++ b/src/java/com/zimbra/solr/MimeTypeTokenizer.java
@@ -2,12 +2,12 @@
  * ***** BEGIN LICENSE BLOCK *****
  * Zimbra Collaboration Suite Server
  * Copyright (C) 2011, 2013 Zimbra Software, LLC.
- * 
+ *
  * The contents of this file are subject to the Zimbra Public License
  * Version 1.4 ("License"); you may not use this file except in
  * compliance with the License.  You may obtain a copy of the License at
  * http://www.zimbra.com/license.
- * 
+ *
  * Software distributed under the License is distributed on an "AS IS"
  * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied.
  * ***** END LICENSE BLOCK *****
@@ -16,7 +16,6 @@ package com.zimbra.solr;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -37,7 +36,7 @@ public final class MimeTypeTokenizer extends Tokenizer {
     private final List<String> tokens = new LinkedList<String>();
     private Iterator<String> itr;
     private final CharTermAttribute termAttr = addAttribute(CharTermAttribute.class);
-    
+
     public MimeTypeTokenizer() {
     	super();
     }
@@ -65,7 +64,7 @@ public final class MimeTypeTokenizer extends Tokenizer {
     @Override
     public boolean incrementToken() throws IOException {
     	clearAttributes();
-    	if (itr.hasNext()) {	
+        if (itr.hasNext()) {
             termAttr.setEmpty().append(itr.next());
             return true;
         } else {
@@ -87,7 +86,6 @@ public final class MimeTypeTokenizer extends Tokenizer {
 			return;
 		}
 	    add(s.toString());
-	    tokens.add(tokens.isEmpty() ? "none" : "any");
 	    itr = tokens.iterator();
     }
 


### PR DESCRIPTION
In the old Lucene architecture, all attachment type strings associated with a message were passed to the `MimeTypeTokenizer` as a list. After extracting tokens from this list, the tokenizer would then add an extra "none" or "any" token depending on if any tokens were indexed; this was used to power `has:attachment` and `not has:attachment` queries.
With the migration to Solr, the `attachment` field was made multi-valued, but the tokenizer was kept the same. The effect was twofold:
1. a "none" token was never indexed, since the absence of attachments would simply result in nothing being indexed in the field
2. searches for `attachment:any` would not work because the "any" term would tokenize into _two_ "any" tokens, which would understandably not yield any hits.

The solution is to simply index the "none" and "any" tokens explicitly, instead of relying on the tokenizer to generate them automatically. On the zm-solr repo, this requires a small update to `MimeTypeTokenizer`. See https://github.com/Zimbra/zm-mailbox/pull/612 for the mailbox-side changes.